### PR TITLE
Nd my parks testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .DS_Store
 node_modules
 /dist
+/coverage
 
 # package-lock.json
 package-lock.json

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,3 +1,4 @@
 module.exports = {
-  preset: '@vue/cli-plugin-unit-jest'
+  preset: '@vue/cli-plugin-unit-jest',
+  collectCoverage: true,
 }

--- a/tests/unit/MyParks.spec.js
+++ b/tests/unit/MyParks.spec.js
@@ -23,4 +23,57 @@ describe('MyParks.vue', () => {
 		expect(wrapper.exists()).toBe(true);
 		expect(wrapper.find('section').isVisible()).toBeTruthy();
 	});
+
+	test('should render a saved park to the screen', () => {
+    const $route = {
+      path: '/my-parks'
+    }
+		state = {
+			savedParks: [
+				{
+					formatted_address: '8270 Lexington Dr, Colorado Springs',
+					geometry: {
+						location: { lat: 38.952039, lng: -104.7748943 },
+						viewport: {
+							northeast: { lat: 38.95328347989272, lng: -104.7738461701073 },
+							southwest: { lat: 38.95058382010728, lng: -104.7765458298927 },
+						},
+					},
+					name: 'Rampart Dog Park',
+					opening_hours: { open_now: true },
+					photos: [
+						{
+							height: 2988,
+							html_attributions: [
+								'<a href="https://maps.google.com/maps/contrib/115566010039288396420">Melodie Marvel</a>',
+							],
+							photo_reference:
+								'ATtYBwKlEoKnkz5JXr2PXbPZ6hkKSQi1vghFDNriwfubSuyxs1CnwgUwMfjXpn4KOOo3sjFqQxGxmwQwx07MiT-apmrrz20QEpBFSA7SWjm4iysxJbiEzhpi6hS3QZzjxUmv_T6z2H4cZcrDRXS404uoQ1cF3M-59L_ExteZXRRaMLirLiDj',
+							width: 5312,
+						},
+					],
+					rating: 4.4,
+				},
+			],
+		};
+		store = new Vuex.Store({
+			state,
+		});
+    const wrapper = mount(MyParks, { 
+      store, 
+      localVue,
+      mocks: {
+        $route
+      },
+    });
+    const getAllH1Tags = wrapper.findAll('h1');
+    const getAllPTags = wrapper.findAll('p');
+    const getAllBtnTags = wrapper.findAll('button');
+    expect(getAllH1Tags.at(1).text()).toBe('Rampart Dog Park');
+    expect(getAllH1Tags.at(2).text()).toBe('8270 Lexington Dr, Colorado Springs');
+    expect(getAllPTags.at(0).text()).toBe('This park is open');
+    expect(getAllPTags.at(1).text()).toBe('Rating: 4.4');
+    expect(getAllBtnTags.at(0).text()).toBe('UNSAVE');
+    expect(getAllBtnTags.at(1).text()).toBe('DETAILS');
+	});
 });

--- a/tests/unit/MyParks.spec.js
+++ b/tests/unit/MyParks.spec.js
@@ -1,0 +1,26 @@
+import { mount, createLocalVue } from '@vue/test-utils';
+import MyParks from '@/components/MyParks.vue';
+import Vuex from 'vuex';
+
+const localVue = createLocalVue();
+localVue.use(Vuex);
+
+describe('MyParks.vue', () => {
+	let state;
+	let store;
+	beforeEach(() => {
+		state = {
+			savedParks: [],
+		};
+
+		store = new Vuex.Store({
+			state,
+		});
+	});
+
+	test('should render MyParks.vue', () => {
+		const wrapper = mount(MyParks, { store, localVue });
+		expect(wrapper.exists()).toBe(true);
+		expect(wrapper.find('section').isVisible()).toBeTruthy();
+	});
+});

--- a/tests/unit/MyParks.spec.js
+++ b/tests/unit/MyParks.spec.js
@@ -22,6 +22,7 @@ describe('MyParks.vue', () => {
 		const wrapper = mount(MyParks, { store, localVue });
 		expect(wrapper.exists()).toBe(true);
 		expect(wrapper.find('section').isVisible()).toBeTruthy();
+		expect(wrapper.find('h1').text()).toBe('My Saved Parks')
 	});
 
 	test('should render a saved park to the screen', () => {

--- a/tests/unit/MyParks.spec.js
+++ b/tests/unit/MyParks.spec.js
@@ -75,5 +75,10 @@ describe('MyParks.vue', () => {
     expect(getAllPTags.at(1).text()).toBe('Rating: 4.4');
     expect(getAllBtnTags.at(0).text()).toBe('UNSAVE');
     expect(getAllBtnTags.at(1).text()).toBe('DETAILS');
-	});
+  });
+  
+  test('should render a message when a user has no parks saved', () => {
+    const wrapper = mount(MyParks, { store, localVue });
+    expect(wrapper.find('h2').text()).toBe('Save a park to view it here!');
+  });
 });


### PR DESCRIPTION
### Participating Group Members:

- Nathan Darrington

### Code Highlights:

- MyParks should render to the screen.
- MyParks should render savedParks to the screen.
- MyParks should render a conditional message to save a park if none are saved.

### Have Tests Been Added?

- [ ] No.
- [ ] Yes, but all tests are not passing.
- [x] Yes, and all are passing.

### Any background context you want to provide?

N/A

### Message/Questions for reviewer:

N/A

### Issues:

- Addresses #
- Closes #86

### Screenshots (if appropriate):

N/A

### Tracking Consistency:

- [x] added appropriate labels
- [x] My code follows the code style of this project and has removed all unnecessary annotations
- [x] I have added comments on my pull request, particularly in hard-to-understand areas
- [x] All new and existing tests passed

- [x] looked at PR preview to check spelling, syntax, formatting, and completion
