### PR TITLE
Sad path results implementation

### DIFF
--- a/src/apiCalls.js
+++ b/src/apiCalls.js
@@ -4,8 +4,18 @@ export const getResults = (coords) => {
     .catch(error => console.error(error))
 }
 
+//If we need a proxy, here is the function we should use: 
+
+// export const getPhoto = (reference) => {
+//   return fetch('https://fe-cors-proxy.herokuapp.com', {
+//     headers: {
+//       "Target-URL": `https://maps.googleapis.com/maps/api/place/photo?maxwidth=400&photoreference=${reference}&key=${process.env.VUE_APP_GOOGLE_MAPS_API_KEY}`
+//     }
+//   })
+//   .catch(err => console.error(err))
+// }
+
 export const getPhoto = (reference) => {
-  return fetch(`https://maps.googleapis.com/maps/api/place/photo?photoreference=${reference}&key=${process.env.VUE_APP_GOOGLE_MAPS_API_KEY}`)
-  .then(res => res.json())
+  return fetch(`https://maps.googleapis.com/maps/api/place/photo?maxwidth=400&photoreference=${reference}&key=${process.env.VUE_APP_GOOGLE_MAPS_API_KEY}`)
   .catch(err => console.error(err))
 }

--- a/src/components/ResultsItemDetails.vue
+++ b/src/components/ResultsItemDetails.vue
@@ -8,8 +8,9 @@
       <p>Address: {{ park.formatted_address }}</p>
     </article>
     <article class='article-description'>
-      <p v-if="park.opening_hours.open_now">Open Now? {{ open }}</p>
+      <p>{{ open }}</p>
       <p>Rating: {{ park.rating }} / 5</p>
+      <img :src='photo'/>
     </article>
     <button class='button-get-directions'>Get Directions</button>
     <!-- button is not functional yet - need to get a directions component w/ router -->
@@ -19,12 +20,13 @@
 </template>
 
 <script>
-// import { getPhoto } from '../apiCalls.js'
+import { getPhoto } from '../apiCalls.js'
 
 export default {
   data() {
     return {
-      parkName: this.$route.params.name
+      parkName: this.$route.params.name,
+      photo: ''
     }
   },
   computed: {
@@ -34,7 +36,7 @@ export default {
       })
     },
     open() {
-      return this.park.opening_hours.open_now === true ? 'Yes' : 'No'
+      return this.park.opening_hours.open_now === true ? 'Open Now' : 'Closed Now'
     }
   },
   methods: {
@@ -42,10 +44,10 @@ export default {
       this.$store.commit('savePark', this.parkName)
     }
   },
-  // mounted() {
-  //   getPhoto(this.park.photos[0].photo_reference)
-  //   .then(data => console.log(data))
-  // }
+  mounted() {
+    getPhoto(this.park.photos[0].photo_reference)
+    .then(data => console.log(data))
+  }
 }
 </script>
 

--- a/src/components/ResultsItemDetails.vue
+++ b/src/components/ResultsItemDetails.vue
@@ -1,7 +1,7 @@
 <template>
   <section>
     <article class='article-button'>
-      <button @click="savePark" class='button-save-park'>SAVE</button>
+      <button @click="savePark" class='button-save-park'>{{ saved }}</button>
     </article>
     <article class='article-destination'>
       <h1 class='detail-descriptor'>{{ park.name }} </h1>
@@ -37,11 +37,18 @@ export default {
     },
     open() {
       return this.park.opening_hours.open_now === true ? 'Open Now' : 'Closed Now'
+    },
+    saved() {
+      if (this.$store.state.savedParks.includes(this.park)) {
+        return 'UNSAVE'
+      } else {
+        return 'SAVE'
+      }
     }
   },
   methods: {
     savePark() {
-      this.$store.commit('savePark', this.parkName)
+      this.$store.commit('savePark', this.park)
     }
   },
   mounted() {

--- a/src/components/ResultsItemDetails.vue
+++ b/src/components/ResultsItemDetails.vue
@@ -53,7 +53,7 @@ export default {
   },
   mounted() {
     getPhoto(this.park.photos[0].photo_reference)
-    .then(data => console.log(data))
+    .then(data => this.photo = data.url)
   }
 }
 </script>

--- a/src/components/ResultsList.vue
+++ b/src/components/ResultsList.vue
@@ -1,7 +1,7 @@
 <template>
-  <section class='results-list' :class="{ loading: !noResults }">
+  <section class='results-list' :class="{ loading: message === 'Loading parks...' }">
     <h4 v-if="!$store.state.searchResults.length">
-      <h5> {{ message }}</h5>
+      <h5>{{ message }}</h5>
       <FindPark v-if="noResults" />
     </h4>
     <section v-else :key='i' v-for='(result, i) in searchResults'>
@@ -35,8 +35,10 @@ export default {
     message() {
       if (this.noResults) {
         return 'Sorry, no results found. Try a different search!'
+      } else if (!this.noResults && !this.$store.state.searchResults.length) {
+        return 'Loading parks...'
       } else {
-        return'Loading parks...'
+        return ''
       }
     }
   }

--- a/src/components/ResultsList.vue
+++ b/src/components/ResultsList.vue
@@ -1,8 +1,8 @@
 <template>
   <section class='results-list'>
     <h4 v-if="!$store.state.searchResults.length">
-      <h5>No results found</h5>
-      <FindPark />
+      <h5> {{ message }}</h5>
+      <FindPark v-if="noResults" />
     </h4>
     <section v-else :key='i' v-for='(result, i) in searchResults'>
       <results-list-item :result='result'></results-list-item>
@@ -15,6 +15,30 @@ import ResultsListItem from './ResultsListItem.vue';
 import FindPark from './FindPark.vue';
 export default {
   props: ['searchResults'],
-  components: { ResultsListItem, FindPark }
+  data() {
+    return {
+      noResults: false
+    }
+  },
+  methods: {
+    load() {
+      if (!this.$store.state.searchResults.length) {
+        this.noResults = true
+      }
+    }
+  },
+  mounted() {
+    setTimeout(() => this.load(), 6000)
+  },
+  components: { ResultsListItem, FindPark },
+  computed: {
+    message() {
+      if (this.noResults) {
+        return 'Sorry, no results found. Try a different search!'
+      } else {
+        return'Loading parks...'
+      }
+    }
+  }
 }
 </script>

--- a/src/components/ResultsList.vue
+++ b/src/components/ResultsList.vue
@@ -1,5 +1,5 @@
 <template>
-  <section class='results-list'>
+  <section class='results-list' :class="{ loading: !noResults }">
     <h4 v-if="!$store.state.searchResults.length">
       <h5> {{ message }}</h5>
       <FindPark v-if="noResults" />
@@ -42,3 +42,9 @@ export default {
   }
 }
 </script>
+
+<style scoped>
+.loading {
+  cursor:  wait;
+}
+</style>


### PR DESCRIPTION
### Participating Group Members:

- @nicolegooden 

### Code Highlights:

- Allows user to see a loading message for up to 6 seconds after searching for nearby parks
- Informs user that there are no results if `searchResults` is empty
- Shows a loading cursor (spinning blue ball) when user hovers around the loading message while it is rendered
- In `ResultsItemDetails`, shows a save button to the user only if the park is not included in `savedParks`. Otherwise, if it is included, an unsave button appears.
- Adds implementation for rendering a photo from Google Places API (doesn't work right now, explanation provided below)

### Have Tests Been Added?

- [X] No.
- [ ] Yes, but all tests are not passing.
- [ ] Yes, and all are passing.

### Any background context you want to provide?

Regarding the photo from Google Places: After I set up the CORS proxy, I was getting a valid response but wasn't able to find any properties in the object that would be useful for a `src`.  The photo object's `url` seemed like the only viable piece of data, and it was set to the path for our proxy.  

@npdarrington and I spent about 30 minutes working on the photo retrieval from Google Places.  Nathan realized that we are able to view the image directly in the browser if we type in the exact path for the GET request, which led us to believe that Google Places doesn't approve of us making the request from `http://localhost` and is instead looking for a request from `https://`.  

I have commented out the version of `getPhoto()` with the CORS proxy for future reference if we need it, and replaced it with a function that makes the request directly.  I have it set up so that, in `ResultsItemDetails`, there is `photo` in `data` and it is set to the `url` we (hopefully) retrieve.  That is then used to render an image in `<template>`.

We are not happy about potentially merging something that does not work, but we figure the best way to test our theory is to merge this and push it to production on Heroku.  Our deployed app has the `https://` prefix.

### Message/Questions for reviewer:

When the results are loading, the user only sees the `wait` cursor (spinning blue ball) when hovering over the loading message, but nowhere else on the DOM.  Any ideas for how to get the `loading` class applied to the entire section?  

I'm wondering if this is a CSS issue, and that the section containing that message is not much bigger than the message itself.

### Issues:

- Closes #93
- Closes #70 
- Closes #69 

### Screenshots (if appropriate):

![Screen Shot 2021-01-11 at 6 55 19 PM](https://user-images.githubusercontent.com/62262404/104261220-4b219980-5442-11eb-8bfc-dd693cdf8f43.png)
![Screen Shot 2021-01-11 at 6 55 28 PM](https://user-images.githubusercontent.com/62262404/104261225-4eb52080-5442-11eb-9766-74be95012d20.png)
![Screen Shot 2021-01-11 at 6 56 02 PM](https://user-images.githubusercontent.com/62262404/104261232-5248a780-5442-11eb-91c2-6af9cb7c78fb.png)

### Tracking Consistency:

- [X] added appropriate labels
- [X] My code follows the code style of this project and has removed all unnecessary annotations
- [ ] I have added comments on my pull request, particularly in hard-to-understand areas
- [X] All new and existing tests passed

- [X] looked at PR preview to check spelling, syntax, formatting, and completion
