### PR TITLE
Fix map centering

### DIFF
--- a/src/components/ResultsMap.vue
+++ b/src/components/ResultsMap.vue
@@ -50,7 +50,14 @@ export default {
 				};
 			}
 		},
-		handleMarkerClick(marker) {
+		resetMap() {
+			this.centerMap = {
+				lat: 0,
+				lng: 0
+			}
+		},
+		async handleMarkerClick(marker) {
+			await this.resetMap()
 			this.centerMapToClickedLocation(marker.name);
 			this.setSelectedMarker(marker.name);
 		},

--- a/src/components/ResultsMap.vue
+++ b/src/components/ResultsMap.vue
@@ -50,14 +50,14 @@ export default {
 				};
 			}
 		},
-		resetMap() {
+		resetCenter() {
 			this.centerMap = {
 				lat: 0,
 				lng: 0
 			}
 		},
 		async handleMarkerClick(marker) {
-			await this.resetMap()
+			await this.resetCenter()
 			this.centerMapToClickedLocation(marker.name);
 			this.setSelectedMarker(marker.name);
 		},


### PR DESCRIPTION
### Participating Group Members:

- @bretm9 

### Code Highlights:

- `ResultsMap.vue`:
  - Added `resetCenter` that sets map's center to `0, 0`
  - `handleMarkerClick` invokes `resetCenter` and awaits it so data (state) is updated and component is re-rendered.

### Have Tests Been Added?

- [x] No.
- [ ] Yes, but all tests are not passing.
- [ ] Yes, and all are passing.

### Any background context you want to provide?
The component would previously not re-render (and therefore not re-center) when clicking the same marker. This is because `setSelectedMarker` wouldn't change the data's `centerMap` property (state) since it was the same value. To fix this I added `resetMap` that updates `mapCenter` to `0, 0`. I had to `await` `centerMap` in `handleMarkerClick` or else the component would still not be re-rendered since the state comparison would only be made between before and after `handleMarkerClick` was fired. `async await` makes the state comparison happen after `centerMap` evaluates and therefore the component re-renders.

### Message/Questions for reviewer:
N/A

### Issues:

- Addresses #
- Closes #42 

### Screenshots (if appropriate):
N/A

### Tracking Consistency:

- [x] added appropriate labels
- [x] My code follows the code style of this project and has removed all unnecessary annotations
- [ ] I have added comments on my pull request, particularly in hard-to-understand areas
- [x] All new and existing tests passed

- [x] looked at PR preview to check spelling, syntax, formatting, and completion
