### PR TITLE
Photo display for ResultsItemDetails

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
     "lint": "vue-cli-service lint"
   },
   "dependencies": {
-    "@splidejs/vue-splide": "^0.3.5",
     "core-js": "^3.6.5",
     "vue": "^2.6.11",
     "vue-router": "^3.2.0",

--- a/src/apiCalls.js
+++ b/src/apiCalls.js
@@ -4,24 +4,8 @@ export const getResults = (coords) => {
     .catch(error => console.error(error))
 }
 
-//If we need a proxy, here is the function we should use: 
-
-// export const getPhoto = (reference) => {
-//   return fetch('https://fe-cors-proxy.herokuapp.com', {
-//     headers: {
-//       "Target-URL": `https://maps.googleapis.com/maps/api/place/photo?maxwidth=400&photoreference=${reference}&key=${process.env.VUE_APP_GOOGLE_MAPS_API_KEY}`
-//     }
-//   })
-//   .catch(err => console.error(err))
-// }
-
 export const getSearch = (searchTerm) => {
   return fetch(`https://boneyard-be.herokuapp.com/api/coordinates=${searchTerm}`)
     .then(response => response.json())
     .catch(error => console.error(error))
-}
-
-export const getPhoto = (reference) => {
-  return fetch(`https://maps.googleapis.com/maps/api/place/photo?maxwidth=400&photoreference=${reference}&key=${process.env.VUE_APP_GOOGLE_MAPS_API_KEY}`)
-  .catch(err => console.error(err))
 }

--- a/src/apiCalls.js
+++ b/src/apiCalls.js
@@ -15,6 +15,12 @@ export const getResults = (coords) => {
 //   .catch(err => console.error(err))
 // }
 
+export const getSearch = (searchTerm) => {
+  return fetch(`https://boneyard-be.herokuapp.com/api/coordinates=${searchTerm}`)
+    .then(response => response.json())
+    .catch(error => console.error(error))
+}
+
 export const getPhoto = (reference) => {
   return fetch(`https://maps.googleapis.com/maps/api/place/photo?maxwidth=400&photoreference=${reference}&key=${process.env.VUE_APP_GOOGLE_MAPS_API_KEY}`)
   .catch(err => console.error(err))

--- a/src/components/Directions.vue
+++ b/src/components/Directions.vue
@@ -1,0 +1,40 @@
+<template>
+  <ol v-if="this.directions.length">
+    <li :key='i' v-for="(direction, i) in directions">
+      {{direction}}  
+    </li>
+  </ol>
+</template>
+
+<script>
+export default {
+  props: ["park"],
+  data() {
+    return {
+      directions: []
+    }
+  },
+  mounted() {
+    // This is where the apiCall for getting directions will happen 
+    // For now there is placeholder functionality for testing purposes
+    this.directions = [
+        "Up",
+        "Up",
+        "Down",
+        "Down",
+        "Left",
+        "Right",
+        "Left",
+        "Right",
+        "B",
+        "A"
+      ]
+    // apiCall functionality might look like this:
+    // this.directions = getDirections(this.park)
+  }
+}
+</script>
+
+<style>
+
+</style>

--- a/src/components/FindPark.vue
+++ b/src/components/FindPark.vue
@@ -41,14 +41,11 @@ export default {
   methods: {
     async search() {
       const results = await getSearch(this.searchTerm)
-        .then((data) => data);
       this.$store.commit('storeResults', results);
       this.searchTerm = '';
     },
     async searchByLocation() {
-      const results = await getResults(
-        this.$store.state.geolocation.coords
-      ).then((data) => data);
+      const results = await getResults(this.$store.state.geolocation.coords)
       this.$store.commit('storeResults', results);
     },
   },

--- a/src/components/FindPark.vue
+++ b/src/components/FindPark.vue
@@ -31,6 +31,7 @@
 
 <script>
 import { getResults } from '../apiCalls.js';
+import { getSearch } from '../apiCalls.js';
 export default {
   data() {
     return {
@@ -38,8 +39,10 @@ export default {
     };
   },
   methods: {
-    search() {
-      //functionality for search goes here...
+    async search() {
+      const results = await getSearch(this.searchTerm)
+        .then((data) => data);
+      this.$store.commit('storeResults', results);
       this.searchTerm = '';
     },
     async searchByLocation() {

--- a/src/components/ResultsItemDetails.vue
+++ b/src/components/ResultsItemDetails.vue
@@ -81,6 +81,9 @@ export default {
   }
 
   img {
-    width: 15em;
+    width: 12em;
+    height: auto;
+    border-radius: 13%;
+    padding: 1em;
   }
 </style>

--- a/src/components/ResultsItemDetails.vue
+++ b/src/components/ResultsItemDetails.vue
@@ -12,21 +12,21 @@
       <p>Rating: {{ park.rating }} / 5</p>
       <!-- <img :src='photo'/> -->
     </article>
-    <button class='button-get-directions'>Get Directions</button>
-    <!-- button is not functional yet - need to get a directions component w/ router -->
+    <button @click="mountDirections" class='button-get-directions'>Get Directions</button>
+    <directions v-if="directionsIsMounted" :park="this.park"></directions>
     <h2>Not the right park for your pup?</h2>
     <router-link to='/'><button>Search Again</button></router-link>
   </section>
 </template>
 
 <script>
-// import { getPhoto } from '../apiCalls.js'
-
+import Directions from './Directions.vue'
 export default {
+  components: { Directions },
   data() {
     return {
       parkName: this.$route.params.name,
-      // photo: ''
+      directionsIsMounted: false
     }
   },
   computed: {
@@ -49,6 +49,9 @@ export default {
   methods: {
     savePark() {
       this.$store.commit('savePark', this.park)
+    },
+    mountDirections() {
+      this.directionsIsMounted = true;
     }
   },
   // mounted() {

--- a/src/components/ResultsItemDetails.vue
+++ b/src/components/ResultsItemDetails.vue
@@ -10,7 +10,7 @@
     <article class='article-description'>
       <p>{{ open }}</p>
       <p>Rating: {{ park.rating }} / 5</p>
-      <!-- <img :src='photo'/> -->
+      <img :src="determinePhoto()" />
     </article>
     <button @click="mountDirections" class='button-get-directions'>Get Directions</button>
     <directions v-if="directionsIsMounted" :park="this.park"></directions>
@@ -52,12 +52,19 @@ export default {
     },
     mountDirections() {
       this.directionsIsMounted = true;
+    },
+    determinePhoto() {
+      const photoRef = this.park.photos[0].photo_reference
+      if (photoRef) {
+        return `https://maps.googleapis.com/maps/api/place/photo?maxwidth=1000
+                &photoreference=${photoRef}
+                &key=${process.env.VUE_APP_GOOGLE_MAPS_API_KEY}`
+      } else {
+        return `https://encrypted-tbn0.gstatic.com/
+                images?q=tbn:ANd9GcSbeshCBceIHNyh82XOdQ-6JZD77uYjUpBVqg&usqp=CAU`
+      }
     }
-  },
-  // mounted() {
-  //   getPhoto(this.park.photos[0].photo_reference)
-  //   .then(data => this.photo = data.url)
-  // }
+  }
 }
 </script>
 
@@ -71,5 +78,9 @@ export default {
 
   button { 
     @include button-main-style
+  }
+
+  img {
+    width: 15em;
   }
 </style>

--- a/src/components/ResultsItemDetails.vue
+++ b/src/components/ResultsItemDetails.vue
@@ -10,7 +10,7 @@
     <article class='article-description'>
       <p>{{ open }}</p>
       <p>Rating: {{ park.rating }} / 5</p>
-      <img :src="determinePhoto()" />
+      <img :src="determinePhoto()" :alt="'photo for ' + park.name" />
     </article>
     <button @click="mountDirections" class='button-get-directions'>Get Directions</button>
     <directions v-if="directionsIsMounted" :park="this.park"></directions>


### PR DESCRIPTION
### Participating Group Members:

- @nicolegooden 
- @npdarrington 

### Code Highlights:

- Removes the splide package from `package.json`
- Removes commented code for `mount` &  `getPhotos( )`
- Allows user to see an image (coming from the first photo's `photo_reference`) on `ResultsItemDetails`
  **(HOORAY!)**
- Allows user to see a random, generic image if the park does not come ready with `photos`
- Adds simple styling to the `<img />` tag
- Removes `getPhotos( )` from `apiCalls.js`

### Have Tests Been Added?

- [X] No.
- [ ] Yes, but all tests are not passing.
- [ ] Yes, and all are passing.

### Any background context you want to provide?

Nathan came to the conclusion that we could set the `img src` to the `url` that successfully obtains the photo.  We set it up so that the api key variable from `.env.local` is interpolated in the string from `determinePhoto( )`, giving us access to the photo.  

### Message/Questions for reviewer:

**Please run another `npm install` so that the splide package isn't unnecessarily installed on your branch**

I wasn't able to verify that the generic image shows up for the user, given that all of my parks have a photo included in the `park` computed object.

### Issues:

- Closes #113
- Closes #114 
- Closes #115 

### Screenshots (if appropriate):

![Screen Shot 2021-01-12 at 2 57 41 PM](https://user-images.githubusercontent.com/62262404/104379319-8d041b80-54e6-11eb-893c-3451fddca47a.png)

### Tracking Consistency:

- [X] added appropriate labels
- [X] My code follows the code style of this project and has removed all unnecessary annotations
- [ ] I have added comments on my pull request, particularly in hard-to-understand areas
- [X] All new and existing tests passed

- [X] looked at PR preview to check spelling, syntax, formatting, and completion
