### PR TITLE
Resize pictures ng

### DIFF
--- a/src/components/ResultsItemDetails.vue
+++ b/src/components/ResultsItemDetails.vue
@@ -98,7 +98,7 @@ export default {
   }
 
   img {
-    width: 90%;
+    width: 35%;
     height: auto;
     border-radius: 13%;
     padding: 1em;

--- a/src/views/TheHome.vue
+++ b/src/views/TheHome.vue
@@ -24,6 +24,6 @@ export default {
 .puppy-picture {
   width: 100%;
   border-radius: 5%;
-  max-width: 1000px;
+  max-width: 500px;
 }
 </style>


### PR DESCRIPTION
### Participating Group Members:

- @nicolegooden 

### Code Highlights:

- Changes the size of the image on `TheHome` and `ResultsItemDetails`

### Have Tests Been Added?

- [X] No.
- [ ] Yes, but all tests are not passing.
- [ ] Yes, and all are passing.

### Any background context you want to provide?

I noticed that the images were showing up very large on the desktop view, so I've made two small edits so that the image doesn't overwhelm the user.

### Message/Questions for reviewer:

N/A

### Issues:

- Closes #149 

### Screenshots (if appropriate):

<img width="1271" alt="Screen Shot 2021-01-14 at 4 23 29 PM" src="https://user-images.githubusercontent.com/62262404/104661214-4993e380-5685-11eb-8fa9-a465597ce053.png">
<img width="485" alt="Screen Shot 2021-01-14 at 4 23 42 PM" src="https://user-images.githubusercontent.com/62262404/104661237-53b5e200-5685-11eb-8efd-ba7b24ec03b7.png">
<img width="1348" alt="Screen Shot 2021-01-14 at 4 24 27 PM" src="https://user-images.githubusercontent.com/62262404/104661240-587a9600-5685-11eb-91ce-794a938b3f41.png">
<img width="496" alt="Screen Shot 2021-01-14 at 4 24 38 PM" src="https://user-images.githubusercontent.com/62262404/104661254-5d3f4a00-5685-11eb-83d6-894fc3bcf04c.png">


### Tracking Consistency:

- [X] added appropriate labels
- [X] My code follows the code style of this project and has removed all unnecessary annotations
- [ ] I have added comments on my pull request, particularly in hard-to-understand areas
- [X] All new and existing tests passed
- [X] looked at PR preview to check spelling, syntax, formatting, and completion
