### PR TITLE
Directions bugfix

### DIFF
--- a/src/components/ResultsItemDetails.vue
+++ b/src/components/ResultsItemDetails.vue
@@ -18,6 +18,7 @@
       <p>Rating: {{ park.rating }} / 5</p>
       <img :src="determinePhoto()" :alt="'photo for ' + park.name" />
     </article>
+    <h2 v-if="!this.$store.state.geolocation">Wanna go play? Enable location services to get directions to this park!</h2>
     <button v-if="this.$store.state.geolocation" @click="mountDirections" class='button-get-directions'>{{ directionButtonText }}</button>
     <directions v-if="directionsIsMounted" :park="this.park"></directions>
     <h2>Not the right park for your pup?</h2>

--- a/src/components/ResultsItemDetails.vue
+++ b/src/components/ResultsItemDetails.vue
@@ -19,7 +19,7 @@
       <img :src="determinePhoto()" :alt="'photo for ' + park.name" />
     </article>
     <h2 id="directions-message" v-if="!this.$store.state.geolocation">Wanna go play? Enable location services to get directions to this park!</h2>
-    <button v-if="this.$store.state.geolocation" @click="mountDirections" class='button-get-directions'>{{ directionButtonText }}</button>
+    <button v-else @click="mountDirections" class='button-get-directions'>{{ directionButtonText }}</button>
     <directions v-if="directionsIsMounted" :park="this.park"></directions>
     <h2 id="park-message">Not the right park for your pup?</h2>
     <router-link to='/results'><button>Explore Results</button></router-link>

--- a/src/components/ResultsItemDetails.vue
+++ b/src/components/ResultsItemDetails.vue
@@ -18,7 +18,7 @@
       <p>Rating: {{ park.rating }} / 5</p>
       <img :src="determinePhoto()" :alt="'photo for ' + park.name" />
     </article>
-    <button @click="mountDirections" class='button-get-directions'>{{ directionButtonText }}</button>
+    <button v-if="this.$store.state.geolocation" @click="mountDirections" class='button-get-directions'>{{ directionButtonText }}</button>
     <directions v-if="directionsIsMounted" :park="this.park"></directions>
     <h2>Not the right park for your pup?</h2>
     <router-link to='/results'><button>Explore Results</button></router-link>

--- a/src/components/ResultsItemDetails.vue
+++ b/src/components/ResultsItemDetails.vue
@@ -18,10 +18,10 @@
       <p>Rating: {{ park.rating }} / 5</p>
       <img :src="determinePhoto()" :alt="'photo for ' + park.name" />
     </article>
-    <h2 v-if="!this.$store.state.geolocation">Wanna go play? Enable location services to get directions to this park!</h2>
+    <h2 id="directions-message" v-if="!this.$store.state.geolocation">Wanna go play? Enable location services to get directions to this park!</h2>
     <button v-if="this.$store.state.geolocation" @click="mountDirections" class='button-get-directions'>{{ directionButtonText }}</button>
     <directions v-if="directionsIsMounted" :park="this.park"></directions>
-    <h2>Not the right park for your pup?</h2>
+    <h2 id="park-message">Not the right park for your pup?</h2>
     <router-link to='/results'><button>Explore Results</button></router-link>
   </section>
 </template>

--- a/tests/unit/ResultsItemDetails.spec.js
+++ b/tests/unit/ResultsItemDetails.spec.js
@@ -93,7 +93,8 @@ describe('ResultsItemDetails', () => {
     expect(wrapper.exists()).toBe(true)
     expect(wrapper.find('section').isVisible()).toBeTruthy();
     expect(wrapper.find('h1').text()).toBe('BoneYard');
-    expect(wrapper.find('h2').text()).toBe('Not the right park for your pup?');
+    expect(wrapper.find('#park-message').text()).toBe('Not the right park for your pup?');
+    expect(wrapper.find('#directions-message').text()).toBe('Wanna go play? Enable location services to get directions to this park!')
 
     const getAllPTags = wrapper.findAll('p');
     expect(getAllPTags.at(0).text()).toBe('Address: 5123-5275 Valmont Rd, Boulder');
@@ -102,8 +103,8 @@ describe('ResultsItemDetails', () => {
 
     const getAllButtonTags = wrapper.findAll('button');
     expect(getAllButtonTags.at(0).text()).toBe('SAVE');
-    expect(getAllButtonTags.at(1).text()).toBe('Show Directions');
-    expect(getAllButtonTags.at(2).text()).toBe('Explore Results');
+    // expect(getAllButtonTags.at(1).text()).toBe('Show Directions');
+    expect(getAllButtonTags.at(1).text()).toBe('Explore Results');
   })
 
   it('should trigger savePark method when save button is clicked', () => {


### PR DESCRIPTION
### Participating Group Members:

- Stacy Potten

### Code Highlights:

- This code renders the `get directions` button conditionally based on whether or not the user has enabled geolocation. 
- This code renders a message encouraging the user to turn on the location services to get directions. 

### Have Tests Been Added?

- [x] No.
- [ ] Yes, but all tests are not passing.
- [ ] Yes, and all are passing.

### Any background context you want to provide?

### Message/Questions for reviewer:

### Issues:

- Closes #146 

### Screenshots (if appropriate):
<img width="864" alt="Screen Shot 2021-01-14 at 4 18 26 PM" src="https://user-images.githubusercontent.com/66034248/104661500-ddfe4600-5685-11eb-84a6-a4ae5a170220.png">
\*

### Tracking Consistency:

- [x] added appropriate labels
- [x] My code follows the code style of this project and has removed all unnecessary annotations
- [x] I have added comments on my pull request, particularly in hard-to-understand areas
- [x] All new and existing tests passed
- [x] looked at PR preview to check spelling, syntax, formatting, and completion
