### PR TITLE
Bug fix for Results View

### DIFF
--- a/src/components/ResultsList.vue
+++ b/src/components/ResultsList.vue
@@ -38,9 +38,7 @@ export default {
   },
   methods: {
     load() {
-      if (!this.$store.state.email) {
-        this.noEmail = true;
-      } else if (!this.$store.state.searchResults.length) {
+      if (!this.$store.state.searchResults.length) {
         this.noResults = true;
       }
     },
@@ -52,7 +50,11 @@ export default {
     },
   },
   mounted() {
-    setTimeout(() => this.load(), 4000);
+    if (!this.$store.state.email) {
+      this.noEmail = true;
+    } else {
+      setTimeout(() => this.load(), 4000);
+    }
   },
   components: { ResultsListItem, FindPark, LoadingIcon },
   computed: {

--- a/src/components/ResultsList.vue
+++ b/src/components/ResultsList.vue
@@ -1,19 +1,23 @@
 <template>
-  <section class='results-list' :class="{ loading: message === 'Loading parks...' }">
+  <section
+    class="results-list"
+    :class="{ loading: message === 'Loading parks...' }"
+  >
     <h3 v-if="message === 'Loading parks...'"><LoadingIcon /></h3>
     <h4 v-if="!$store.state.searchResults.length">
-      <h5>{{ message }}</h5>
+      <h5 class="message">{{ message }}</h5>
       <FindPark v-if="noResults" />
     </h4>
     <section v-else class="list-results">
       <button v-if="!sorted" @click="sortByRating">Sort By Rating</button>
       <h4 v-else>Parks are sorted from highest to lowest rating below.</h4>
-        <section class="result-items">
-          <results-list-item
-            v-for="(result, i) in searchResults"
-            :key="i"
-            :result='result'></results-list-item>
-        </section>
+      <section class="result-items">
+        <results-list-item
+          v-for="(result, i) in searchResults"
+          :key="i"
+          :result="result"
+        ></results-list-item>
+      </section>
     </section>
   </section>
 </template>
@@ -28,38 +32,43 @@ export default {
   data() {
     return {
       noResults: false,
-      sorted: false
-    }
+      noEmail: false,
+      sorted: false,
+    };
   },
   methods: {
     load() {
-      if (!this.$store.state.searchResults.length) {
-        this.noResults = true
+      if (!this.$store.state.email) {
+        this.noEmail = true;
+      } else if (!this.$store.state.searchResults.length) {
+        this.noResults = true;
       }
     },
     sortByRating() {
       this.$store.state.searchResults.sort((parkA, parkB) => {
-        return parkB.rating - parkA.rating
-      })
-      this.sorted = true
-    }
+        return parkB.rating - parkA.rating;
+      });
+      this.sorted = true;
+    },
   },
   mounted() {
-    setTimeout(() => this.load(), 6000)
+    setTimeout(() => this.load(), 4000);
   },
   components: { ResultsListItem, FindPark, LoadingIcon },
   computed: {
     message() {
-      if (this.noResults) {
-        return 'Sorry, no results found. Try a different search!'
+      if (this.noEmail) {
+        return 'Return Home to sign in with your email and search for parks.';
+      } else if (this.noResults) {
+        return 'Sorry, no results found. Try a different search!';
       } else if (!this.noResults && !this.$store.state.searchResults.length) {
-        return 'Loading parks...'
+        return 'Loading parks...';
       } else {
-        return ''
+        return '';
       }
-    }
-  }
-}
+    },
+  },
+};
 </script>
 
 <style lang="scss" scoped>
@@ -83,13 +92,14 @@ export default {
     }
   }
 }
-
+.message {
+  font-size: 20px;
+}
 .loading {
-  cursor:  wait;
+  cursor: wait;
 }
 
 button {
   @include button-main-style;
 }
-
 </style>


### PR DESCRIPTION
### Participating Group Members:

- Stacy 
- Bret
- Nathan

### Code Highlights:

- This pr addresses the bug that allowed users to navigate to the `results list` with out entering their email. 
- Adds a `noEmail` property to the `data()` on `ResultsList`
- Adds conditionals to `load()` and `message()` to properly render the error message

### Have Tests Been Added?

- [x] No.
- [ ] Yes, but all tests are not passing.
- [ ] Yes, and all are passing.

### Any background context you want to provide?

### Message/Questions for reviewer:
- Do we want the loading message/animation to render if the user skips the email? Or just go straight to the error message? It does currently render. 
- I shortened the `setTimeout` to 4 seconds because 6 felt long to me, but we can change it back if needed. 

### Issues:

- Closes #151 

### Screenshots (if appropriate):
<img width="684" alt="Screen Shot 2021-01-26 at 3 59 44 PM" src="https://user-images.githubusercontent.com/66034248/105917425-85b53580-5fef-11eb-8ee5-626c6a1bb362.png">


### Tracking Consistency:

- [x] added appropriate labels
- [x] My code follows the code style of this project and has removed all unnecessary annotations
- [ ] I have added comments on my pull request, particularly in hard-to-understand areas
- [x] All new and existing tests passed
- [x] looked at PR preview to check spelling, syntax, formatting, and completion
